### PR TITLE
Fix/malformatted-id

### DIFF
--- a/src/tests/tweet.test.js
+++ b/src/tests/tweet.test.js
@@ -117,7 +117,7 @@ describe('Tweets', () => {
       expect(userProps).not.toContain('password');
     });
 
-    test.only('should fail with 404 Tweet Not Found if tweet not found', async () => {
+    test('should fail with 404 Tweet Not Found if tweet not found', async () => {
       const response = await api
         .get('/api/tweets/12347f2a5039068dc8ac561f')
         .expect(404);

--- a/src/tests/user.test.js
+++ b/src/tests/user.test.js
@@ -178,7 +178,7 @@ describe('Users', () => {
       expect(usersIds).not.toContain(userId);
     });
 
-    test.only('should get whotofollow users that user has not followed', async () => {
+    test('should get whotofollow users that user has not followed', async () => {
       const usersAtStart = await usersInDb();
       const userId = usersAtStart[0].id;
 

--- a/src/validations/tweets.js
+++ b/src/validations/tweets.js
@@ -8,8 +8,8 @@ const createTweet = yup.object({
       .string()
       .trim()
       .nullable()
-      .test('isValidObjectId', 'malformatted id', (value) =>
-        isValidObjectId(value)
+      .test('isValidObjectId', 'malformatted id', (id) =>
+        !id ? true : isValidObjectId(id)
       ),
   }),
 });


### PR DESCRIPTION
### Description
Fix 'malformatted id ' validation error when creating Tweets without a parent.
Add validation to allow parent to be null or undefined.